### PR TITLE
added missing giantswarm/builder dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Clone the latest git repository version from here: https://github.com/giantswarm
  * `tmux`
  * `qemu` (>=2.4, including kvm support)
  * `linux`
+ *  [builder](https://github.com/giantswarm/builder) (compiled and included in $PATH)
 
 #### Building the standard way
 


### PR DESCRIPTION
Makefile use `builder` and it was not listed in prerequisites 
